### PR TITLE
create_view -> create_design_doc

### DIFF
--- a/couchbase/client.py
+++ b/couchbase/client.py
@@ -284,7 +284,7 @@ class Bucket(object):
             view = key.split('/')[1]
 
             rest = self.server._rest()
-            rest.create_view(self.bucket_name, view, json.dumps(value))
+            rest.create_design_doc(self.bucket_name, view, json.dumps(value))
         else:
             if '_rev' in value:
                 # couchbase works in clobber mode so for a "set" _rev is useless


### PR DESCRIPTION
The `Bucket.save` method currently calls `RestClient.create_view`, which doesn't exist. This patch calls `RestClient.create_design_doc` instead.
