### PR TITLE
Please verify multi-level key support in the python interface

### DIFF
--- a/couchbase/rest_client.py
+++ b/couchbase/rest_client.py
@@ -208,7 +208,7 @@ class RestConnection(object):
                          "startkey_docid", "endkey_docid"] or \
                          params[param] is True or \
                          params[param] is False:
-                api += "%s=%s" % (param, json.dumps(params[param]))
+                api += "%s=%s" % (param, json.dumps(params[param], separators=(',',':')))
             else:
                 api += "%s=%s" % (param, params[param])
 


### PR DESCRIPTION
...paces after each level.

This solves the bug of not being able to retrieve multi-valued keys as in the snippet below. 
bucket.view('_design/packets/_view/all', key=[u'05B3DCE1C2E21400', 0, 65537, 8916], limit=10)

By applying this change the produced string for the rest interface is:
'["05B3DCE1C2E21400",0,65537,8916]' instead of the incorrect '["05B3DCE1C2E21400", 0, 65537, 8916]'

In fact, I don't see the reason why the latter should be giving troubles. 
It all points to a possibly incorrect url-encoding of the produced string.

Anyways, removing the spaces solves the problem
