### PR TITLE
Hot loop hogs CPU

### DIFF
--- a/couchbase/couchbaseclient.py
+++ b/couchbase/couchbaseclient.py
@@ -22,6 +22,8 @@ import socket
 import zlib
 import urllib
 import warnings
+import time
+
 try:
     import json
 except ImportError:


### PR DESCRIPTION
Fixed a hot loop that hogged CPU usage at 100% for the dispatcher thread.
Fix tested under Debian Squeeze and Mac OS X 10.7
