### PR TITLE
Restore basic functionality of couchbase-python-client

### DIFF
--- a/couchbase/rest_client.py
+++ b/couchbase/rest_client.py
@@ -279,7 +279,7 @@ class RestConnection(object):
             return {'Content-Type': 'application/x-www-form-urlencoded',
                     'Accept': '*/*'}
 
-    def _http_request(self, api, method='GET', params='', headers=None,
+    def _http_request(self, api, method='GET', params=None, headers=None,
                       timeout=120, base=None):
         if base is None:
             base = self.base_url


### PR DESCRIPTION
Beginning with commit ffc72ac the library `requests` explicitly expects `None` if no value is given and raises ValueError if out encounters an empty string `''` so that couchbase-python-client does not work with the current version.
