### PR TITLE
Bugfix for the "got not my vb error"

### DIFF
--- a/couchbase/couchbaseclient.py
+++ b/couchbase/couchbaseclient.py
@@ -87,7 +87,6 @@ class CommandDispatcher(object):
                         #  with fast forward map vbucket
                         self.log.error(ex)
                         if hasattr(ex, 'vbucket'):
-                            print "HERE!"
                             self.reconfig_callback(ex.vbucket)
                             self.start_connection_callback(ex.vbucket)
                         else:


### PR DESCRIPTION
The code that was in there just had a little bug. I fixed a broken if statement and things started working.

I tested this during a rebalance, saw the errors, and also saw my client continue to function fine. Before I did the patch, we'd get hit with a "30 second timeout" from the memcached client. 
