### PR TITLE
the installation includes couchbase.views

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,5 +78,5 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Python Modules"],
     ext_modules = [module],
-    packages = ['couchbase']
+    packages = ['couchbase', 'couchbase.views']
 )


### PR DESCRIPTION
`packages` in `setup.py` includes only `'couchbase'`. It should include `'couchbase.views'` also. Otherwise, `setup.py` installs just `couchbase` without `couchbase.views`.

My small patch fixes this problem. Please merge.
