### PR TITLE
Slight tweak to documentation about default lockmode

### DIFF
--- a/docs/source/api/threads.rst
+++ b/docs/source/api/threads.rst
@@ -64,15 +64,13 @@ threads
 
 .. data:: LOCKMODE_EXC
 
-This is the default lockmode. If it is detected that the object is being used
+*This is the default lockmode*. If it is detected that the object is being used
 from multiple threads, an exception will be raised indicating such.
 
 Internally this uses the C equivalent of the ``threading.Lock`` object (i.e.
 ``PyThread_allocate_lock()``). Upon each entry to a function it will try
 to acquire the lock (without waiting). If the acquisition fails, the
 exception is raised.
-
-*This is the default lockmode*
 
 .. data:: LOCKMODE_WAIT
 


### PR DESCRIPTION
When documentation HTML is generated, there is some ambiguity about to
which section the italicised "This is the default lockmode" applies: the
text appears at the end of the LOCKMODE_EXC section and immediately
before LOCKMODE_WAIT, with no visible separators except an empty line.

The default LOCKMODE_EXC section already begins with exactly the same
statement.  This change removes the trailing redundant and
confusingly-located statement and puts the italics on the original,
unambiguously-located statement.