### PR TITLE
fixed bug in code example of lock()

### DIFF
--- a/couchbase/connection.py
+++ b/couchbase/connection.py
@@ -576,6 +576,7 @@ class Connection(_Base):
             while time.time() - begin_time < 15:
                 try:
                     rv = cb.lock("key")
+                    break
                 except TemporaryFailError:
                     print("Key is currently locked.. waiting")
                     time.sleep(0)


### PR DESCRIPTION
The code example in the comment of lock() didn't work. Without the 'break' the loop goes on and on and tries again to lock the key which will fail with TemporaryFailError.