### PR TITLE
Migrating from travis-ci legacy infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,33 @@
 language: python
+sudo: false
 
 python:
   - "2.7"
   - "2.6"
   - "3.2"
   - "3.3"
+  - "3.4"
+  - "3.5"
 
-before_install:
-  - sudo rm -rf /etc/apt/sources.list.d/*
-  - wget -O- http://packages.couchbase.com/ubuntu/couchbase.key | sudo apt-key add -
-  - echo deb http://packages.couchbase.com/ubuntu precise precise/main | sudo tee /etc/apt/sources.list.d/couchbase.list
-  - sudo apt-get update
-  - sudo apt-cache search libcouchbase
+addons:
+  apt:
+    sources:
+      - couchbase-precise
+    packages:
+      - libcouchbase-dev
+      - libcouchbase2-libevent
+      - libevent-dev
 
 install:
-  - sudo apt-get -y install libcouchbase-dev libcouchbase2-core libcouchbase2-libevent libevent-dev
-  - pip -q install gevent || echo "Couldn't find gevent"
-  - pip -q install twisted
-  - pip -q install testresources
+  - pip install -U pip
+  - pip install gevent || echo "Couldn't find gevent"
+  # Twisted install can fail, as Twisted requires Python 2.7 or later
+  - pip install twisted || echo "Couldn't install twisted"
+  - pip install testresources
   - export CFLAGS='-Wextra -Wno-long-long -Wno-missing-field-initializers'
   - CFLAGS="$CFLAGS -fno-strict-aliasing -Wno-strict-aliasing"
   - python setup.py build_ext --inplace
-  - sudo $(which python) setup.py install
+  - python setup.py install
 
 script:
   - ./.ci_script.sh


### PR DESCRIPTION
I noticed some failed tests during https://github.com/couchbase/couchbase-python-client/pull/29, this results in green builds for me.

Summary of changes are below...

see here: https://docs.travis-ci.com/user/migrating-from-legacy/

* Remove requirements for sudo
* Start testing python 3.4 and 3.4
* Allow twisted install to fail, it will on python2.6
* Remove quiet flag from pip install (for future debugging)