### PR TITLE
Expose the acouchbase module, improve support for view queries and N1QL queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
   - "2.6"
   - "3.2"
   - "3.3"
+  - "3.4"
+  - "3.5"
 
 addons:
   apt:
@@ -29,6 +31,7 @@ script:
   - python -m couchbase.bucket
   - cp .tests.ini.travis tests.ini
   - nosetests -v couchbase.tests.test_sync
+  - nosetests -v acouchbase
   - nosetests -v gcouchbase.tests.test_api || echo "Gevent tests failed"
   - nosetests -v txcouchbase || echo "Twisted tests failed"
 

--- a/acouchbase/bucket.py
+++ b/acouchbase/bucket.py
@@ -4,6 +4,7 @@ except ImportError:
     import trollius as asyncio
 
 from acouchbase.asyncio_iops import IOPS
+from acouchbase.iterator import ViewRowProcessor, N1QLRowProcessor
 from couchbase.async.bucket import AsyncBucket
 from couchbase.experimental import enabled_or_raise; enabled_or_raise()
 
@@ -41,6 +42,16 @@ class Bucket(AsyncBucket):
             return ft
 
         return ret
+
+    def query(self, *args, **kwargs):
+        if "itercls" not in kwargs:
+            kwargs["itercls"] = ViewRowProcessor
+        return super().query(*args, **kwargs)
+
+    def n1ql_query(self, *args, **kwargs):
+        if "itercls" not in kwargs:
+            kwargs["itercls"] = N1QLRowProcessor
+        return super().n1ql_query(*args, **kwargs)
 
     locals().update(AsyncBucket._gen_memd_wrappers(_meth_factory))
 

--- a/acouchbase/bucket.py
+++ b/acouchbase/bucket.py
@@ -4,7 +4,7 @@ except ImportError:
     import trollius as asyncio
 
 from acouchbase.asyncio_iops import IOPS
-from acouchbase.iterator import ViewRowProcessor, N1QLRowProcessor
+from acouchbase.iterator import AView, AN1QLRequest
 from couchbase.async.bucket import AsyncBucket
 from couchbase.experimental import enabled_or_raise; enabled_or_raise()
 
@@ -45,12 +45,12 @@ class Bucket(AsyncBucket):
 
     def query(self, *args, **kwargs):
         if "itercls" not in kwargs:
-            kwargs["itercls"] = ViewRowProcessor
+            kwargs["itercls"] = AView
         return super().query(*args, **kwargs)
 
     def n1ql_query(self, *args, **kwargs):
         if "itercls" not in kwargs:
-            kwargs["itercls"] = N1QLRowProcessor
+            kwargs["itercls"] = AN1QLRequest
         return super().n1ql_query(*args, **kwargs)
 
     locals().update(AsyncBucket._gen_memd_wrappers(_meth_factory))

--- a/acouchbase/iterator.py
+++ b/acouchbase/iterator.py
@@ -59,14 +59,14 @@ class AioBase:
         self.__accumulator.put_nowait(None)
 
 
-class ViewRowProcessor(AioBase, AsyncViewBase):
+class AView(AioBase, AsyncViewBase):
 
     def __init__(self, *args, **kwargs):
         AsyncViewBase.__init__(self, *args, **kwargs)
         AioBase.__init__(self)
 
 
-class N1QLRowProcessor(AioBase, AsyncN1QLRequest):
+class AN1QLRequest(AioBase, AsyncN1QLRequest):
 
     def __init__(self, *args, **kwargs):
         AsyncN1QLRequest.__init__(self, *args, **kwargs)

--- a/acouchbase/iterator.py
+++ b/acouchbase/iterator.py
@@ -1,0 +1,75 @@
+import asyncio
+from couchbase.async.view import AsyncViewBase
+from couchbase.async.n1ql import AsyncN1QLRequest
+
+class AioBase:
+    def __init__(self):
+        self.__local_done = False
+        self.__accumulator = asyncio.Queue()
+        self._future = asyncio.Future()
+        self.start()
+        self.raw.rows_per_call = 1000
+
+    @property
+    @asyncio.coroutine
+    def future(self):
+        yield from self._future
+        self.__accumulator = [j for j in iter(self.__accumulator.get_nowait, None) if j is not None]
+
+    @asyncio.coroutine
+    def __iter__(self):
+        if isinstance(self.__accumulator, asyncio.Queue):
+            raise ValueError("yield from result.future before calling non-async for.")
+
+        yield from self.__accumulator
+
+    @asyncio.coroutine
+    def __aiter__(self):
+        if not isinstance(self.__accumulator, asyncio.Queue):
+            raise ValueError("do not yield from result.future before calling async for.")
+
+        return self
+
+    @asyncio.coroutine
+    def __anext__(self):
+        try:
+            out = None
+            if self._future.done() and not self.__accumulator.empty():
+                out = self.__accumulator.get_nowait()
+            elif not self._future.done():
+                out = yield from self.__accumulator.get()
+
+            if out is None:
+                raise StopAsyncIteration
+
+            return out
+        except asyncio.queues.QueueEmpty:
+            raise StopAsyncIteration
+
+    def on_rows(self, rowiter):
+        for row in rowiter:
+            self.__accumulator.put_nowait(row)
+
+    def on_done(self):
+        self._future.set_result(None)
+        self.__accumulator.put_nowait(None)
+
+    def on_error(self, ex):
+        self._future.set_exception(ex)
+        self.__accumulator.put_nowait(None)
+
+
+class ViewRowProcessor(AioBase, AsyncViewBase):
+
+    def __init__(self, *args, **kwargs):
+        AsyncViewBase.__init__(self, *args, **kwargs)
+        AioBase.__init__(self)
+
+
+class N1QLRowProcessor(AioBase, AsyncN1QLRequest):
+
+    def __init__(self, *args, **kwargs):
+        AsyncN1QLRequest.__init__(self, *args, **kwargs)
+        AioBase.__init__(self)
+
+

--- a/acouchbase/tests/asyncio_tests.py
+++ b/acouchbase/tests/asyncio_tests.py
@@ -1,52 +1,7 @@
-import asyncio
-import unittest
-
-from couchbase.experimental import enable; enable()
-from fixtures import asynct, AioTestCase, beer_bucket, default_bucket
-from couchbase.n1ql import N1QLQuery
-
-
-class CouchBaseTest(AioTestCase):
-
-    @asynct
-    def test_get_data(self):
-        yield from (beer_bucket.connect() or asyncio.sleep(0.01))
-
-        data = yield from beer_bucket.get('21st_amendment_brewery_cafe')
-        self.assertEqual("21st Amendment Brewery Cafe", data.value["name"])
-
-    @asynct
-    @asyncio.coroutine
-    def test_query(self):
-        yield from (beer_bucket.connect() or asyncio.sleep(0.01))
-        viewiter = beer_bucket.query("beer", "brewery_beers", limit=10)
-        yield from viewiter.future
-
-        count = len(list(viewiter))
-
-        self.assertEqual(count, 10)
-
-
-
-    @asynct
-    @asyncio.coroutine
-    def test_upsert(self):
-        yield from (default_bucket.connect() or asyncio.sleep(0.01))
-
-        yield from default_bucket.upsert('hello', {"key": "test"})
-
-    @asynct
-    @asyncio.coroutine
-    def test_n1ql(self):
-        yield from (default_bucket.connect() or asyncio.sleep(0.01))
-
-        q = N1QLQuery("SELECT name, category, ibu, brewery_id FROM `beer-sample` WHERE  brewery_id = $input_filter LIMIT 15", input_filter='abita_brewing_company')
-        it = beer_bucket.n1ql_query(q)
-        yield from it.future
-
-        data = list(it)
-        self.assertEqual(len(data), 15)
-        self.assertEqual(len([x for x in data if x["brewery_id"] == "abita_brewing_company"]), 15)
+try:
+    from py34only import CouchBaseTest
+except SyntaxError:
+    pass
 
 try:
     from py35only import CouchBasePy35Test

--- a/acouchbase/tests/asyncio_tests.py
+++ b/acouchbase/tests/asyncio_tests.py
@@ -1,0 +1,54 @@
+import asyncio
+import unittest
+
+from couchbase.experimental import enable; enable()
+from fixtures import asynct, AioTestCase, beer_bucket, default_bucket
+from couchbase.n1ql import N1QLQuery
+
+
+class CouchBaseTest(AioTestCase):
+
+    @asynct
+    def test_get_data(self):
+        yield from (beer_bucket.connect() or asyncio.sleep(0.01))
+
+        data = yield from beer_bucket.get('21st_amendment_brewery_cafe')
+        self.assertEqual("21st Amendment Brewery Cafe", data.value["name"])
+
+    @asynct
+    @asyncio.coroutine
+    def test_query(self):
+        yield from (beer_bucket.connect() or asyncio.sleep(0.01))
+        viewiter = beer_bucket.query("beer", "brewery_beers", limit=10)
+        yield from viewiter.future
+
+        count = len(list(viewiter))
+
+        self.assertEqual(count, 10)
+
+
+
+    @asynct
+    @asyncio.coroutine
+    def test_upsert(self):
+        yield from (default_bucket.connect() or asyncio.sleep(0.01))
+
+        yield from default_bucket.upsert('hello', {"key": "test"})
+
+    @asynct
+    @asyncio.coroutine
+    def test_n1ql(self):
+        yield from (default_bucket.connect() or asyncio.sleep(0.01))
+
+        q = N1QLQuery("SELECT name, category, ibu, brewery_id FROM `beer-sample` WHERE  brewery_id = $input_filter LIMIT 15", input_filter='abita_brewing_company')
+        it = beer_bucket.n1ql_query(q)
+        yield from it.future
+
+        data = list(it)
+        self.assertEqual(len(data), 15)
+        self.assertEqual(len([x for x in data if x["brewery_id"] == "abita_brewing_company"]), 15)
+
+try:
+    from py35only import CouchBasePy35Test
+except SyntaxError:
+    pass

--- a/acouchbase/tests/asyncio_tests.py
+++ b/acouchbase/tests/asyncio_tests.py
@@ -2,14 +2,14 @@
 # ImportError will fail for python 3.3 because asyncio does not exist
 
 try:
-    from py34only import CouchBaseTest
+    from py34only import CouchbaseTest
 except ImportError:
     pass
 except SyntaxError:
     pass
 
 try:
-    from py35only import CouchBasePy35Test
+    from py35only import CouchbasePy35Test
 except ImportError:
     pass
 except SyntaxError:

--- a/acouchbase/tests/asyncio_tests.py
+++ b/acouchbase/tests/asyncio_tests.py
@@ -2,7 +2,7 @@
 # ImportError will fail for python 3.3 because asyncio does not exist
 
 try:
-    from py34only import CouchbaseTest
+    from py34only import CouchbaseBeerTest, CouchbaseDefaultTest
 except ImportError:
     pass
 except SyntaxError:

--- a/acouchbase/tests/asyncio_tests.py
+++ b/acouchbase/tests/asyncio_tests.py
@@ -1,9 +1,16 @@
+# SyntaxError will trigger if yield or async is not supported
+# ImportError will fail for python 3.3 because asyncio does not exist
+
 try:
     from py34only import CouchBaseTest
+except ImportError:
+    pass
 except SyntaxError:
     pass
 
 try:
     from py35only import CouchBasePy35Test
+except ImportError:
+    pass
 except SyntaxError:
     pass

--- a/acouchbase/tests/fixtures.py
+++ b/acouchbase/tests/fixtures.py
@@ -1,21 +1,10 @@
 import asyncio
 import unittest
 
-from couchbase.tests.base import ConnectionConfiguration, MockResourceManager
+from couchbase.tests.base import ConnectionConfiguration, MockResourceManager, MockTestCase
 from acouchbase.bucket import Bucket
 
 from functools import wraps
-
-config = ConnectionConfiguration()
-
-manager = MockResourceManager(config)
-mock_info = manager.make()
-if mock_info:
-    beer_bucket = mock_info.make_connection(Bucket, bucket="beer-sample")
-    default_bucket = mock_info.make_connection(Bucket)
-else:
-    beer_bucket = None
-    default_bucket = None
 
 
 def asynct(f):
@@ -27,8 +16,6 @@ def asynct(f):
 
     return wrapper
 
-class AioTestCase(unittest.TestCase):
-
-    def setUp(self):
-        if not beer_bucket:
-            self.skipTest("Mock Server required.")
+class AioTestCase(MockTestCase):
+    factory = Bucket
+    should_check_refcount = False

--- a/acouchbase/tests/fixtures.py
+++ b/acouchbase/tests/fixtures.py
@@ -1,20 +1,22 @@
 import asyncio
 import unittest
 
-from couchbase.tests.base import ConnectionConfiguration
+from couchbase.tests.base import ConnectionConfiguration, MockResourceManager
 from acouchbase.bucket import Bucket
 
 from functools import wraps
 
 config = ConnectionConfiguration()
-cluster_info = config.realserver_info
 
-if cluster_info:
-    beer_bucket = cluster_info.make_connection(Bucket, bucket="beer-sample")
-    default_bucket = cluster_info.make_connection(Bucket)
+manager = MockResourceManager(config)
+mock_info = manager.make()
+if mock_info:
+    beer_bucket = mock_info.make_connection(Bucket, bucket="beer-sample")
+    default_bucket = mock_info.make_connection(Bucket)
 else:
     beer_bucket = None
     default_bucket = None
+
 
 def asynct(f):
     @wraps(f)
@@ -28,5 +30,5 @@ def asynct(f):
 class AioTestCase(unittest.TestCase):
 
     def setUp(self):
-        if not cluster_info:
-            self.skipTest("Real Server required.")
+        if not beer_bucket:
+            self.skipTest("Mock Server required.")

--- a/acouchbase/tests/fixtures.py
+++ b/acouchbase/tests/fixtures.py
@@ -1,0 +1,26 @@
+import asyncio
+import unittest
+
+from couchbase.tests.base import ConnectionConfiguration
+from acouchbase.bucket import Bucket
+
+from functools import wraps
+
+config = ConnectionConfiguration()
+cluster_info = config.realserver_info
+
+beer_bucket = cluster_info.make_connection(Bucket, bucket="beer-sample")
+default_bucket = cluster_info.make_connection(Bucket)
+
+def asynct(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        future = f(*args, **kwargs)
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(future)
+
+    return wrapper
+
+class AioTestCase(unittest.TestCase):
+    pass
+    

--- a/acouchbase/tests/fixtures.py
+++ b/acouchbase/tests/fixtures.py
@@ -9,8 +9,12 @@ from functools import wraps
 config = ConnectionConfiguration()
 cluster_info = config.realserver_info
 
-beer_bucket = cluster_info.make_connection(Bucket, bucket="beer-sample")
-default_bucket = cluster_info.make_connection(Bucket)
+if cluster_info:
+    beer_bucket = cluster_info.make_connection(Bucket, bucket="beer-sample")
+    default_bucket = cluster_info.make_connection(Bucket)
+else:
+    beer_bucket = None
+    default_bucket = None
 
 def asynct(f):
     @wraps(f)
@@ -22,5 +26,7 @@ def asynct(f):
     return wrapper
 
 class AioTestCase(unittest.TestCase):
-    pass
-    
+
+    def setUp(self):
+        if not cluster_info:
+            self.skipTest("Real Server required.")

--- a/acouchbase/tests/py34only.py
+++ b/acouchbase/tests/py34only.py
@@ -1,0 +1,50 @@
+import asyncio
+import unittest
+
+from couchbase.experimental import enable; enable()
+from fixtures import asynct, AioTestCase, beer_bucket, default_bucket
+from couchbase.n1ql import N1QLQuery
+
+
+class CouchBaseTest(AioTestCase):
+
+    @asynct
+    def test_get_data(self):
+        yield from (beer_bucket.connect() or asyncio.sleep(0.01))
+
+        data = yield from beer_bucket.get('21st_amendment_brewery_cafe')
+        self.assertEqual("21st Amendment Brewery Cafe", data.value["name"])
+
+    @asynct
+    @asyncio.coroutine
+    def test_query(self):
+        yield from (beer_bucket.connect() or asyncio.sleep(0.01))
+        viewiter = beer_bucket.query("beer", "brewery_beers", limit=10)
+        yield from viewiter.future
+
+        count = len(list(viewiter))
+
+        self.assertEqual(count, 10)
+
+
+
+    @asynct
+    @asyncio.coroutine
+    def test_upsert(self):
+        yield from (default_bucket.connect() or asyncio.sleep(0.01))
+
+        yield from default_bucket.upsert('hello', {"key": "test"})
+
+    @asynct
+    @asyncio.coroutine
+    def test_n1ql(self):
+        yield from (default_bucket.connect() or asyncio.sleep(0.01))
+
+        q = N1QLQuery("SELECT name, category, ibu, brewery_id FROM `beer-sample` WHERE  brewery_id = $input_filter LIMIT 15", input_filter='abita_brewing_company')
+        it = beer_bucket.n1ql_query(q)
+        yield from it.future
+
+        data = list(it)
+        self.assertEqual(len(data), 15)
+        self.assertEqual(len([x for x in data if x["brewery_id"] == "abita_brewing_company"]), 15)
+

--- a/acouchbase/tests/py34only.py
+++ b/acouchbase/tests/py34only.py
@@ -2,16 +2,23 @@ import asyncio
 import unittest
 
 from couchbase.experimental import enable; enable()
-from fixtures import asynct, AioTestCase, beer_bucket, default_bucket
+from fixtures import asynct, AioTestCase
 from couchbase.n1ql import N1QLQuery
 
 
 
-class CouchbaseTest(AioTestCase):
+class CouchbaseBeerTest(AioTestCase):
+
+    def make_connection(self):
+        try:
+            return super().make_connection(bucket='beer-sample')
+        except CouchbaseError:
+            raise SkipTest("Need 'beer-sample' bucket for this")
 
     @asynct
     @asyncio.coroutine
     def test_get_data(self):
+        beer_bucket = self.cb
         yield from (beer_bucket.connect() or asyncio.sleep(0.01))
 
         data = yield from beer_bucket.get('21st_amendment_brewery_cafe')
@@ -20,6 +27,8 @@ class CouchbaseTest(AioTestCase):
     @asynct
     @asyncio.coroutine
     def test_query(self):
+        beer_bucket = self.cb
+
         yield from (beer_bucket.connect() or asyncio.sleep(0.01))
         viewiter = beer_bucket.query("beer", "brewery_beers", limit=10)
         yield from viewiter.future
@@ -29,6 +38,7 @@ class CouchbaseTest(AioTestCase):
         self.assertEqual(count, 10)
 
 
+class CouchbaseDefaultTest(AioTestCase):
 
     @asynct
     @asyncio.coroutine
@@ -37,6 +47,7 @@ class CouchbaseTest(AioTestCase):
 
         expected = str(uuid.uuid4())
 
+        default_bucket = self.cb
         yield from (default_bucket.connect() or asyncio.sleep(0.01))
 
         yield from default_bucket.upsert('hello', {"key": expected})
@@ -48,6 +59,8 @@ class CouchbaseTest(AioTestCase):
     @asynct
     @asyncio.coroutine
     def test_n1ql(self):
+
+        default_bucket = self.cb
         yield from (default_bucket.connect() or asyncio.sleep(0.01))
 
         q = N1QLQuery("SELECT mockrow")

--- a/acouchbase/tests/py34only.py
+++ b/acouchbase/tests/py34only.py
@@ -6,9 +6,11 @@ from fixtures import asynct, AioTestCase, beer_bucket, default_bucket
 from couchbase.n1ql import N1QLQuery
 
 
+
 class CouchbaseTest(AioTestCase):
 
     @asynct
+    @asyncio.coroutine
     def test_get_data(self):
         yield from (beer_bucket.connect() or asyncio.sleep(0.01))
 
@@ -35,16 +37,16 @@ class CouchbaseTest(AioTestCase):
 
         yield from default_bucket.upsert('hello', {"key": "test"})
 
+
     @asynct
     @asyncio.coroutine
     def test_n1ql(self):
         yield from (default_bucket.connect() or asyncio.sleep(0.01))
 
-        q = N1QLQuery("SELECT name, category, ibu, brewery_id FROM `beer-sample` WHERE  brewery_id = $input_filter LIMIT 15", input_filter='abita_brewing_company')
-        it = beer_bucket.n1ql_query(q)
+        q = N1QLQuery("SELECT mockrow")
+        it = default_bucket.n1ql_query(q)
         yield from it.future
 
         data = list(it)
-        self.assertEqual(len(data), 15)
-        self.assertEqual(len([x for x in data if x["brewery_id"] == "abita_brewing_company"]), 15)
+        self.assertEqual('value', data[0]['row'])
 

--- a/acouchbase/tests/py34only.py
+++ b/acouchbase/tests/py34only.py
@@ -33,9 +33,16 @@ class CouchbaseTest(AioTestCase):
     @asynct
     @asyncio.coroutine
     def test_upsert(self):
+        import uuid
+
+        expected = str(uuid.uuid4())
+
         yield from (default_bucket.connect() or asyncio.sleep(0.01))
 
-        yield from default_bucket.upsert('hello', {"key": "test"})
+        yield from default_bucket.upsert('hello', {"key": expected})
+
+        obtained = yield from default_bucket.get('hello')
+        self.assertEqual({"key": expected}, obtained.value)
 
 
     @asynct

--- a/acouchbase/tests/py34only.py
+++ b/acouchbase/tests/py34only.py
@@ -6,7 +6,7 @@ from fixtures import asynct, AioTestCase, beer_bucket, default_bucket
 from couchbase.n1ql import N1QLQuery
 
 
-class CouchBaseTest(AioTestCase):
+class CouchbaseTest(AioTestCase):
 
     @asynct
     def test_get_data(self):

--- a/acouchbase/tests/py35only.py
+++ b/acouchbase/tests/py35only.py
@@ -1,7 +1,6 @@
-import unittest
 from fixtures import asynct, AioTestCase, beer_bucket, default_bucket
 
-class CouchBasePy35Test(unittest.TestCase):
+class CouchBasePy35Test(AioTestCase):
 
     @asynct
     async def test_query_with_async_iterator(self):

--- a/acouchbase/tests/py35only.py
+++ b/acouchbase/tests/py35only.py
@@ -1,6 +1,6 @@
 from fixtures import asynct, AioTestCase, beer_bucket, default_bucket
 
-class CouchBasePy35Test(AioTestCase):
+class CouchbasePy35Test(AioTestCase):
 
     @asynct
     async def test_query_with_async_iterator(self):

--- a/acouchbase/tests/py35only.py
+++ b/acouchbase/tests/py35only.py
@@ -1,0 +1,15 @@
+import unittest
+from fixtures import asynct, AioTestCase, beer_bucket, default_bucket
+
+class CouchBasePy35Test(unittest.TestCase):
+
+    @asynct
+    async def test_query_with_async_iterator(self):
+        await (beer_bucket.connect() or asyncio.sleep(0.01))
+        viewiter = beer_bucket.query("beer", "brewery_beers", limit=10)
+
+        count = 0
+        async for row in viewiter:
+            count += 1
+
+        self.assertEqual(count, 10)

--- a/acouchbase/tests/py35only.py
+++ b/acouchbase/tests/py35only.py
@@ -1,9 +1,16 @@
-from fixtures import asynct, AioTestCase, beer_bucket, default_bucket
+from fixtures import asynct, AioTestCase
 
 class CouchbasePy35Test(AioTestCase):
 
+    def make_connection(self):
+        try:
+            return super().make_connection(bucket='beer-sample')
+        except CouchbaseError:
+            raise SkipTest("Need 'beer-sample' bucket for this")
+
     @asynct
     async def test_query_with_async_iterator(self):
+        beer_bucket = self.cb
         await (beer_bucket.connect() or asyncio.sleep(0.01))
         viewiter = beer_bucket.query("beer", "brewery_beers", limit=10)
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,5 @@
 nose==1.3.0
+pbr==1.8.1
 numpydoc==0.4
 sphinx==1.2b1
 testresources>=0.2.7

--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules"],
 
     packages = [
+        'acouchbase',
         'couchbase',
         'couchbase.views',
         'couchbase.iops',

--- a/tests.ini.sample
+++ b/tests.ini.sample
@@ -22,4 +22,4 @@ enabled = True
 ; Local path for the mock
 path = /tmp/CouchbaseMock-1.0.0-g50cf222.jar
 ; Where to download it, if not available
-url = http://packages.coucbase.com/clients/c/mock/CouchbaseMock-LATEST.jar
+url = http://packages.couchbase.com/clients/c/mock/CouchbaseMock-LATEST.jar


### PR DESCRIPTION
When installing the library through pip, the acouchbase module is not available, unlike txcouchbase and gcouchbase.