### PR TITLE
Fix PYCBC-344

### DIFF
--- a/gcouchbase/tests/test_gevent.py
+++ b/gcouchbase/tests/test_gevent.py
@@ -1,0 +1,42 @@
+from couchbase.tests.base import SkipTest
+try:
+    import gevent
+except ImportError as e:
+    raise SkipTest(e)
+
+from gcouchbase.bucket import Bucket, GView
+from couchbase.tests.base import ConnectionTestCase
+
+
+class GeventSpecificTest(ConnectionTestCase):
+    factory = Bucket
+    viewfactory = GView
+    should_check_refcount = False
+
+    def test_killing_greenlet(self):
+        foo = self.gen_key('foo')
+        bar = self.gen_key('bar')
+        self.cb.upsert(foo, 'foo')
+        self.cb.upsert(bar, 'bar')
+        def load_foo_and_bar_forever():
+            while True:
+                try:
+                    r = self.cb.get(foo)
+                except gevent.GreenletExit:
+                    continue
+                else:
+                    self.assertEqual(r.value, 'foo')
+                try:
+                    r = self.cb.get(bar)
+                except gevent.GreenletExit:
+                    continue
+                else:
+                    self.assertEqual(r.value, 'bar')
+        def kill_greenlet_forever(g):
+            while True:
+                gevent.sleep(0.1)
+                g.kill()
+        g = gevent.spawn(load_foo_and_bar_forever)
+        greenlets = [g, gevent.spawn(kill_greenlet_forever, g)]
+        with gevent.Timeout(1, False):
+            gevent.joinall(greenlets, raise_error=True)


### PR DESCRIPTION
I reported the issue at https://issues.couchbase.com/browse/PYCBC-344.

This patch has 2 commits.  The first one creates a test case to reproduce the issue.  You can get a failure by:

```
$ nosetests --tests=gcouchbase.tests.test_gevent
F
======================================================================
FAIL: test_killing_greenlet (gcouchbase.tests.test_gevent.GeventSpecificTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  ...
AssertionError: u'foo' != 'bar'

----------------------------------------------------------------------
Ran 1 test in 2.509s

FAILED (failures=1)
```

The second one fixes the issue by clear callbacks when `GreenletExit` is detected:

```
$ nosetests --tests=gcouchbase.tests.test_gevent
.
----------------------------------------------------------------------
Ran 1 test in 3.337s

OK
```

It's a critical issue for all `gcouchbase` users.  Please review and accept this pull request.