### PR TITLE
Fix PYCBC-344 when timed out

### DIFF
--- a/gcouchbase/bucket.py
+++ b/gcouchbase/bucket.py
@@ -109,11 +109,10 @@ class Bucket(AsyncBucket):
         cbasync.set_callbacks(cur_thread.switch, errback)
         try:
             return get_hub().switch()
-        except GreenletExit:
+        finally:
             # Deregister callbacks to prevent another request on the same
             # greenlet to get the result from this context.
             cbasync.set_callbacks(dummy_callback, dummy_callback)
-            raise
 
     def _meth_factory(meth, name):
         def ret(self, *args, **kwargs):

--- a/gcouchbase/tests/test_gevent.py
+++ b/gcouchbase/tests/test_gevent.py
@@ -1,3 +1,5 @@
+from itertools import cycle
+
 from couchbase.tests.base import SkipTest
 try:
     import gevent
@@ -13,30 +15,47 @@ class GeventSpecificTest(ConnectionTestCase):
     viewfactory = GView
     should_check_refcount = False
 
+    def setUp(self):
+        super(GeventSpecificTest, self).setUp()
+        self.foo = self.gen_key('foo')
+        self.bar = self.gen_key('bar')
+        self.cb.upsert(self.foo, 'foo')
+        self.cb.upsert(self.bar, 'bar')
+
     def test_killing_greenlet(self):
-        foo = self.gen_key('foo')
-        bar = self.gen_key('bar')
-        self.cb.upsert(foo, 'foo')
-        self.cb.upsert(bar, 'bar')
         def load_foo_and_bar_forever():
-            while True:
+            for key, value in cycle([(self.foo, 'foo'), (self.bar, 'bar')]):
                 try:
-                    r = self.cb.get(foo)
+                    r = self.cb.get(key)
                 except gevent.GreenletExit:
                     continue
                 else:
-                    self.assertEqual(r.value, 'foo')
-                try:
-                    r = self.cb.get(bar)
-                except gevent.GreenletExit:
-                    continue
-                else:
-                    self.assertEqual(r.value, 'bar')
+                    self.assertEqual(r.value, value)
         def kill_greenlet_forever(g):
             while True:
                 gevent.sleep(0.1)
                 g.kill()
         g = gevent.spawn(load_foo_and_bar_forever)
         greenlets = [g, gevent.spawn(kill_greenlet_forever, g)]
-        with gevent.Timeout(1, False):
-            gevent.joinall(greenlets, raise_error=True)
+        try:
+            with gevent.Timeout(1, False):
+                gevent.joinall(greenlets, raise_error=True)
+        finally:
+            gevent.killall(greenlets, StopIteration)
+
+    def test_timeout(self):
+        def load_foo_and_bar_forever():
+            for key, value in cycle([(self.foo, 'foo'), (self.bar, 'bar')]):
+                try:
+                    with gevent.Timeout(0.0000001):
+                        r = self.cb.get(key)
+                except gevent.Timeout:
+                    continue
+                else:
+                    self.assertEqual(r.value, value)
+        g = gevent.spawn(load_foo_and_bar_forever)
+        try:
+            with gevent.Timeout(1, False):
+                g.get()
+        finally:
+            g.kill(StopIteration)


### PR DESCRIPTION
I found another failure case when the greenlet timed out.  Here's an example code to reproduce this problem: https://gist.github.com/sublee/4b5796ad7a56bf2342fefe5d40b0332b#file-gcouchbase-wrong-callback-timeout-py

This pull request improves my previous pull request.  Async result callbacks should be cleared after `switch()` always.  Because `switch()` can raise any exceptions.  For example, when the greenlet is within a timeout context, the `swicth()` may raise `gevent.Timeout`.

Please review it one more time.