### PR TITLE
Store reference count of 'excinstance' before assert

### DIFF
--- a/src/exceptions.c
+++ b/src/exceptions.c
@@ -45,6 +45,7 @@ pycbc_exc_wrap_REAL(int mode, struct pycbc_exception_params *p)
     PyObject *excparams;
     PyObject *excinstance;
     PyObject *ctor_args;
+    int excinstance_refcnt;
 
     PyErr_Fetch(&type, &value, &traceback);
     PyErr_Clear();
@@ -96,9 +97,10 @@ pycbc_exc_wrap_REAL(int mode, struct pycbc_exception_params *p)
         Py_XDECREF(traceback);
 
     } else {
+        excinstance_refcnt = (int)Py_REFCNT(excinstance);
         Py_INCREF(Py_TYPE(excinstance));
         PyErr_Restore((PyObject*)Py_TYPE(excinstance), excinstance, traceback);
-        PYCBC_REFCNT_ASSERT(Py_REFCNT(excinstance) == 1);
+        PYCBC_REFCNT_ASSERT(Py_REFCNT(excinstance) == excinstance_refcnt);
     }
 }
 

--- a/src/exceptions.c
+++ b/src/exceptions.c
@@ -45,7 +45,7 @@ pycbc_exc_wrap_REAL(int mode, struct pycbc_exception_params *p)
     PyObject *excparams;
     PyObject *excinstance;
     PyObject *ctor_args;
-    int excinstance_refcnt;
+    Py_ssize_t excinstance_refcnt;
 
     PyErr_Fetch(&type, &value, &traceback);
     PyErr_Clear();
@@ -97,7 +97,7 @@ pycbc_exc_wrap_REAL(int mode, struct pycbc_exception_params *p)
         Py_XDECREF(traceback);
 
     } else {
-        excinstance_refcnt = (int)Py_REFCNT(excinstance);
+        excinstance_refcnt = Py_REFCNT(excinstance);
         Py_INCREF(Py_TYPE(excinstance));
         PyErr_Restore((PyObject*)Py_TYPE(excinstance), excinstance, traceback);
         PYCBC_REFCNT_ASSERT(Py_REFCNT(excinstance) == excinstance_refcnt);


### PR DESCRIPTION
If the frame is saved for debugging purposes in a profiler or the like, the reference count value of `excinstance` is not 1.

look at the test code below.

```python
# -*- coding: utf-8 -*-
# test.py

from __future__ import unicode_literals, print_function

import os
import signal
import sys

from couchbase.bucket import Bucket
from couchbase.exceptions import NotFoundError

# Connect to the default bucket on local host
cb = Bucket('couchbase://127.0.0.1/default')


frames = {}


def signal_handler(signum, frame):
    global frames
    print ('Signal handler called', signum)
    frames.update(sys._current_frames())  # store frames for debugging purpose

signal.signal(signal.SIGPROF, signal_handler)
signal.setitimer(signal.ITIMER_PROF, 0.1, 0.0001)

print ('pid:', os.getpid())
print ('Waiting for a few seconds..')

while True:
    try:
        # Get the document that didn't exist
        item = cb.get('not-exists')
    except NotFoundError:
        pass
```


OS: Ubuntu 16.04
Python: 2.7

## result:
```bash
$ python test.py
pid: 23146
Waiting for a few seconds..
Signal handler called 27
python-couchbase: Py_REFCNT(excinstance) == 1 at src/exceptions.c:105. Abort[1]    23146 abort (core dumped)  python test.py
```
