### PR TITLE
GEventIOEvent, GEventTimer calls super constructor

### DIFF
--- a/gcouchbase/iops_gevent10.py
+++ b/gcouchbase/iops_gevent10.py
@@ -28,6 +28,7 @@ REVERSERMAP = {
 
 class GEventIOEvent(IOEvent):
     def __init__(self):
+        super(GEventIOEvent, self).__init__()
         self.ev = get_hub().loop.io(0,0)
 
     def ready_proxy(self, event):
@@ -42,6 +43,7 @@ class GEventIOEvent(IOEvent):
 
 class GEventTimer(TimerEvent):
     def __init__(self):
+        super(GEventTimer, self).__init__()
         self.ev = get_hub().loop.timer(0)
 
     def ready_proxy(self, *args):


### PR DESCRIPTION
To make it work with couchbase_ffi, `GEventTimer` should have `_cdata` attribute which is initialized by `couchbase_ffi.iops.Event.__init__()`.  But `GEventTimer` didn't call its super constructor.