### PR TITLE
Fix "TypeError: _assign_kwargs() got an unexpected keyword argument '…

### DIFF
--- a/couchbase/fulltext.py
+++ b/couchbase/fulltext.py
@@ -694,7 +694,7 @@ class GeoDistanceQuery(Query):
         super(GeoDistanceQuery, self).__init__()
         kwargs['distance'] = distance
         kwargs['location'] = location
-        _assign_kwargs(self, **kwargs)
+        _assign_kwargs(self, kwargs)
 
     location = _genprop(_location_conv, 'location', doc='Location')
     distance = _genprop_str('distance')
@@ -706,7 +706,7 @@ class GeoBoundingBoxQuery(Query):
         super(GeoBoundingBoxQuery, self).__init__()
         kwargs['top_left'] = top_left
         kwargs['bottom_right'] = bottom_right
-        _assign_kwargs(self, **kwargs)
+        _assign_kwargs(self, kwargs)
 
     top_left = _genprop(
         _location_conv, 'top_left',


### PR DESCRIPTION
…distance'"

At the moment when you try to use `GeoDistanceQuery` you will get:
```sh
Traceback (most recent call last):
  File "test.py", line 208, in <module>
    for city in cities:
  File "test.py", line 103, in get_by_coordinates
    GeoDistanceQuery('1km', (lon, lat)),
  File "/my-path/venv/lib/python3.6/site-packages/couchbase/fulltext.py", line 697, in __init__
    _assign_kwargs(self, **kwargs)
TypeError: _assign_kwargs() got an unexpected keyword argument 'distance'
```

Problem occurs on `Python 3.6.4` and `Python 3.4.3`