### PR TITLE
Some errors don't have a 'key'. Gracefully degrade.

### DIFF
--- a/couchbase/exceptions.py
+++ b/couchbase/exceptions.py
@@ -195,10 +195,12 @@ class CouchbaseError(Exception):
 
         ret_ok, ret_fail = {}, {}
         for v in self.all_results.values():
+            key = getattr(v, 'key', None)
+
             if v.success:
-                ret_ok[v.key] = v
+                ret_ok[key] = v
             else:
-                ret_fail[v.key] = v
+                ret_fail[key] = v
 
         return ret_ok, ret_fail
 

--- a/couchbase/tests/cases/n1ql_t.py
+++ b/couchbase/tests/cases/n1ql_t.py
@@ -17,6 +17,7 @@
 
 from __future__ import print_function
 
+from couchbase.exceptions import HTTPError
 from couchbase.tests.base import MockTestCase
 from couchbase.n1ql import N1QLQuery
 
@@ -35,6 +36,14 @@ class N1QLTest(MockTestCase):
         self.assertRaises(RuntimeError, getattr, q, 'meta')
         q.execute()
         self.assertIsInstance(q.meta, dict)
+
+    def test_httperror_str(self):
+        q = self.cb.n1ql_query('CREATE INDEX abc#123 ON abc (col_1)')
+
+        with self.assertRaises(HTTPError) as c:
+            q.execute()
+
+        self.assertIn('0x3B', str(c.exception))
 
     def test_profile(self):
         query = N1QLQuery('SELECT 1')


### PR DESCRIPTION
The test should show what I'm talking about. Specifically I'm using:

ubuntu 18.04
python 3.6.5
libcouchbase-dev 2.9.5-1
couchbase Community Edition 5.1.1 build 5723

not quite sure why some `ViewResult`s don't have `key` attributes, but this seems to fix it.
