### PR TITLE
bugfix: correct way to remove prefix

### DIFF
--- a/couchbase/management/views.py
+++ b/couchbase/management/views.py
@@ -36,10 +36,9 @@ class DesignDocumentNamespace(Enum):
 
     @classmethod
     def unprefix(cls, name):
-        # could have _design/...
-        name = name.lstrip('_design/')
-        # could have _dev
-        return name.lstrip('_dev')
+        for prefix in ('_design/', '_dev'):
+            name = name[name.startswith(prefix) and len(prefix):]
+        return name
 
 
 


### PR DESCRIPTION
`DesignDocumentNamespace.unprefix("dorking")` will return `orking` which is wrong.

Workaround:
```
ddname = "dorking"
design_doc = DesignDocument(ddname, views)
# workaround for bug: DesignDocumentNamespace.unprefix
design_doc._name = ddname
```