### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/couchbase/tests_v3/cases/cluster_t.py
+++ b/couchbase/tests_v3/cases/cluster_t.py
@@ -99,7 +99,7 @@ class ClusterTests(CollectionTestCase):
         self.assertIn("imareportid", result.id)
         self.assertIsNotNone(result.sdk)
         self.assertIsNotNone(result.version)
-        self.assertEquals(result.state, ClusterState.Online)
+        self.assertEqual(result.state, ClusterState.Online)
         if not self.is_mock:
             # no matter what there should be a config service type in there,
             # as long as we are not the mock.
@@ -153,7 +153,7 @@ class ClusterTests(CollectionTestCase):
         self.assertIn("imareportid", result.id)
         self.assertIsNotNone(result.sdk)
         self.assertIsNotNone(result.version)
-        self.assertEquals(result.state, ClusterState.Online)
+        self.assertEqual(result.state, ClusterState.Online)
         result_str = result.as_json()
         self.assertIsInstance(result_str, str)
         result_json = json.loads(result_str)

--- a/couchbase/tests_v3/cases/scenarios_t.py
+++ b/couchbase/tests_v3/cases/scenarios_t.py
@@ -471,7 +471,7 @@ class Scenarios(CollectionTestCase):
         count = 0
         for row in result.rows():
             count += 1
-        self.assertEquals(1, count)
+        self.assertEqual(1, count)
 
     @staticmethod
     def get_multi_result_as_dict(result):

--- a/couchbase/tests_v3/cases/searchmgmt_t.py
+++ b/couchbase/tests_v3/cases/searchmgmt_t.py
@@ -168,4 +168,4 @@ class SearchIndexManagerTestCase(CollectionTestCase):
         analysis = self.try_n_times(
             5, 2, self.indexmgr.analyze_document, self.indexname, doc)
         self.assertIsNotNone(analysis)
-        self.assertEquals(analysis['status'], 'ok')
+        self.assertEqual(analysis['status'], 'ok')

--- a/couchbase/tests_v3/cases/usermgmt_t.py
+++ b/couchbase/tests_v3/cases/usermgmt_t.py
@@ -391,7 +391,7 @@ class UserManagementTests(CollectionTestCase):
                                          user.username,
                                          GetUserOptions(domain_name="local"))
 
-        self.assertEquals(user_metadata.user.display_name, user.display_name)
+        self.assertEqual(user_metadata.user.display_name, user.display_name)
 
         self.um.drop_user(user.username, DropUserOptions(domain_name="local"))
 

--- a/couchbase_tests/base.py
+++ b/couchbase_tests/base.py
@@ -1042,7 +1042,7 @@ class ClusterTestCase(CouchbaseTestCase):
             self._parent = parent
 
         def assertDsValue(self, expected, item):
-            self._parent.assertEquals(expected, item)
+            self._parent.assertEqual(expected, item)
 
         def assertSuccess(self, item):
             pass


### PR DESCRIPTION
The deprecated aliases have been removed in python/cpython#28268 . `assertEqual` is present in both Python 2 and 3. So the PR is backwards compatible.