### PR TITLE
docs: Fix a few typos

### DIFF
--- a/couchbase/cluster.py
+++ b/couchbase/cluster.py
@@ -1043,7 +1043,7 @@ class Cluster(CoreClient):
 
         """
         # in this context, if we invoke the _cluster's destructor, that will do same for
-        # all the buckets we've opened, unless they are stored elswhere and are actively
+        # all the buckets we've opened, unless they are stored elsewhere and are actively
         # being used.
         self._cluster = None
         self.__admin = None

--- a/couchbase/search.py
+++ b/couchbase/search.py
@@ -142,7 +142,7 @@ class Facet(object):
     @property
     def encodable(self):
         """
-        Returns a reprentation of the object suitable for serialization
+        Returns a representation of the object suitable for serialization
         """
         return self._json_
 

--- a/couchbase_core/mapper.py
+++ b/couchbase_core/mapper.py
@@ -27,7 +27,7 @@ class Bijection(Generic[Src, Dest, SrcToDest, DestToSrc]):
 
         :param src_to_dest: callable to convert Src type to Dest
         :param dest_to_src: callable to convert Dest type to Src
-        :param parent: interanl use only - used to construct the inverse
+        :param parent: internal use only - used to construct the inverse
         """
         self._src_to_dest = src_to_dest
         if parent:

--- a/couchbase_core/priv_constants.py
+++ b/couchbase_core/priv_constants.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# This file constains private constants. This should be used internally
+# This file contains private constants. This should be used internally
 # and is to avoid version/compilation dependencies on newer LCBs
 
 CMDSUBDOC_F_UPSERT_DOC = 1 << 16

--- a/couchbase_tests/base.py
+++ b/couchbase_tests/base.py
@@ -1208,7 +1208,7 @@ class ClusterTestCase(CouchbaseTestCase):
     def setUp(self, **kwargs):
         super(ClusterTestCase, self).setUp()
 
-        # if kwargs are passed in, reset conneciton w/ specied options
+        # if kwargs are passed in, reset connection w/ specied options
         if kwargs:
             if type(self)._cluster_resource:
                 type(self)._cluster_resource.disconnect_cluster()

--- a/docs/source/api/acouchbase.rst
+++ b/docs/source/api/acouchbase.rst
@@ -18,7 +18,7 @@ asynchronous nature. Where the synchronous API returns a
 an :class:`AsyncResult` which will have its callback invoked with a result.
 
 As such, we will omit the mentions of the normal key value operations, which
-function identially to their synchronous conterparts documented in the
+function identically to their synchronous conterparts documented in the
 :class:`~couchbase.cluster.Cluster` :class:`~couchbase.bucket.Bucket`,
 and :class:`~couchbase.collection.Collection` classes.
 

--- a/src/pycbc.h
+++ b/src/pycbc.h
@@ -355,7 +355,7 @@ enum {
     /** Schedule destruction of iops and lcb instance for later */
     PYCBC_CONN_F_ASYNC_DTOR = 1 << 5,
 
-    // Set after inital attempt to retrieve server version
+    // Set after initial attempt to retrieve server version
     PYCBC_GET_VERSION_ATTEMPT = 1 << 6
 };
 

--- a/txcouchbase/cluster.py
+++ b/txcouchbase/cluster.py
@@ -209,7 +209,7 @@ class TxRawClientMixin(object):
           value may be `_dtor` which will register an event to fire when this
           object has been completely destroyed.
 
-        :param event: The defered to fire when the event succeeds or failes
+        :param event: The defered to fire when the event succeeds or fails
         :type event: :class:`Deferred`
 
         If this event has already fired, the deferred will be triggered


### PR DESCRIPTION
There are small typos in:
- couchbase/cluster.py
- couchbase/search.py
- couchbase_core/mapper.py
- couchbase_core/priv_constants.py
- couchbase_tests/base.py
- docs/source/api/acouchbase.rst
- src/pycbc.h
- txcouchbase/cluster.py

Fixes:
- Should read `representation` rather than `reprentation`.
- Should read `internal` rather than `interanl`.
- Should read `initial` rather than `inital`.
- Should read `fails` rather than `failes`.
- Should read `identically` rather than `identially`.
- Should read `elsewhere` rather than `elswhere`.
- Should read `contains` rather than `constains`.
- Should read `connection` rather than `conneciton`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md