### PR TITLE
Update decode_value method in wrappers.py

### DIFF
--- a/couchbase/logic/wrappers.py
+++ b/couchbase/logic/wrappers.py
@@ -35,7 +35,7 @@ from couchbase.exceptions import exception as CouchbaseBaseException
 
 def decode_value(transcoder, value, flags, is_subdoc=False):
     # if no flags, just assume default
-    if not flags:
+    if flags is None:
         flags = FMT_JSON
 
     if is_subdoc is False:


### PR DESCRIPTION
Due to customized transcoder support, we are using flag=0 as our type code . This change is to allow the 0 flag otherwise flag will be enforced to FMT_JSON which will decode error.